### PR TITLE
fix partial matches

### DIFF
--- a/R/tt_download_file.R
+++ b/R/tt_download_file.R
@@ -67,7 +67,7 @@ tt_download_file.character <-
 
   file_info <- attr(tt, ".files")
 
-  if (x %in% file_info$data_file) {
+  if (x %in% file_info$data_files) {
 
     tt_date <- attr(tt, ".date")
     tt_year <- year(tt_date)
@@ -80,7 +80,7 @@ tt_download_file.character <-
         auth = auth
       )
 
-    tt_parse_blob(blob, file_info = file_info[file_info$data_file == x,], ...)
+    tt_parse_blob(blob, file_info = file_info[file_info$data_files == x,], ...)
 
   } else {
     stop(paste0(

--- a/R/tt_parse.R
+++ b/R/tt_parse.R
@@ -15,9 +15,9 @@ tt_parse_blob <- function(blob, ..., file_info) {
     "xls"  = tt_parse_binary(blob, readxl::read_xls, ...,
                              filename = file_info$data_files),
     "xlsx" = tt_parse_binary(blob, readxl::read_xlsx, ...,
-                             filename = file_info$data_file),
+                             filename = file_info$data_files),
     "rds"  = tt_parse_binary(blob, readRDS,
-                             filename = file_info$data_file),
+                             filename = file_info$data_files),
     tt_parse_text(
       blob = blob,
       func = readr::read_delim,
@@ -34,7 +34,7 @@ tt_parse_blob <- function(blob, ..., file_info) {
 }
 
 # rda option just in case
-# "rda"  = tt_parse_binary(blob, read_rda, filename = file_info$data_file),
+# "rda"  = tt_parse_binary(blob, read_rda, filename = file_info$data_files),
 
 
 #' @title utility to assist with parsing the raw binary data

--- a/tests/testthat/test-06-tt_parse_blob.R
+++ b/tests/testthat/test-06-tt_parse_blob.R
@@ -61,7 +61,7 @@ test_that("`tt_parse_blob` can figure out how to handle text or raw",{
     tt_parse_blob(
       blob = "col1,col2\nval1,val2\nval3,val4",
       file_info = data.frame(
-        data_file = "text.txt",
+        data_files = "text.txt",
         data_type = "txt",
         delim = ",",
         stringsAsFactors = FALSE
@@ -72,7 +72,7 @@ test_that("`tt_parse_blob` can figure out how to handle text or raw",{
     tt_parse_blob(
       "col1\tcol2\nval1\tval2\nval3\tval4",
       file_info = data.frame(
-        data_file = "text.txt",
+        data_files = "text.txt",
         data_type = "txt",
         delim = "\t",
         stringsAsFactors = FALSE
@@ -82,7 +82,7 @@ test_that("`tt_parse_blob` can figure out how to handle text or raw",{
   result_text_special <-
     tt_parse_blob(
       "col1|col2\nval1|val2\nval3|val4",
-      file_info = data.frame(data_file = "text.txt",
+      file_info = data.frame(data_files = "text.txt",
                              data_type = "txt",
                              delim = "|", stringsAsFactors = FALSE)
     )
@@ -90,7 +90,7 @@ test_that("`tt_parse_blob` can figure out how to handle text or raw",{
   result_raw_rda <-
     tt_parse_blob(
       input_raw,
-      file_info = data.frame(data_file = "test_rds.rds",
+      file_info = data.frame(data_files = "test_rds.rds",
                              data_type = "rds",
                              delim = "")
     )
@@ -99,7 +99,7 @@ test_that("`tt_parse_blob` can figure out how to handle text or raw",{
     tt_parse_blob(
       blob = "col1,col2\nval1,val2\nval3,val4",
       file_info = data.frame(
-        data_file = "text.csv",
+        data_files = "text.csv",
         data_type = "csv",
         delim = NA,
         stringsAsFactors = FALSE


### PR DESCRIPTION
Fixes #82 

Note that it would be best to activate these options and environment variables when developing a package

```r
options(
  warnPartialMatchArgs = TRUE,
  warnPartialMatchDollar = TRUE,
  warnPartialMatchAttr = TRUE
)

Sys.setenv(
  `_R_CHECK_LENGTH_1_CONDITION_` = "true",
  `_R_CHECK_LENGTH_1_LOGIC2_` = "true"
)
```